### PR TITLE
feat: create target directory before generating types

### DIFF
--- a/src/main/java/com/github/havardh/javaflow/plugins/JavaflowMojo.java
+++ b/src/main/java/com/github/havardh/javaflow/plugins/JavaflowMojo.java
@@ -7,6 +7,7 @@ import static java.util.Collections.singletonList;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -115,6 +116,7 @@ public class JavaflowMojo extends AbstractMojo {
     );
 
     try {
+      prepareTargetDirectory(targetDirectory);
       String outputFile = targetDirectory + "/" + api.getOutput();
       Files.write(Paths.get(outputFile), asList(flow.split("\n")));
       getLog().info(format("Wrote %d types to %s.", files.size(), outputFile));
@@ -154,5 +156,10 @@ public class JavaflowMojo extends AbstractMojo {
     }
 
     return verifiers;
+  }
+
+  private void prepareTargetDirectory(String targetDirectory) throws IOException {
+    Path outputPath = Paths.get(targetDirectory);
+    Files.createDirectories(outputPath);
   }
 }


### PR DESCRIPTION
Creates the target directory before generating the types as discussed in issue #4.

The [`Files.createDirectories`](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#createDirectories(java.nio.file.Path,%20java.nio.file.attribute.FileAttribute...)) method will create the folder if it does not exist and do nothing otherwise.