### PR TITLE
docs: add info for `verifyGetters` flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,9 +33,8 @@ Add the following to the plugins section of your `pom.xml` file.
           <java.math.BigDecimal>number</java.math.BigDecimal>
         </types>
         <verifications>
-          <!-- optional flag specifying if the engine should verify that -->
-          <!-- the number of getters is the same as the number of fields and -->
-          <!-- the types of the fields are the same as the types returned from the getters -->
+          <!-- optional flag specifying if the engine should use the `ClassGetterNamingVerifier` -->
+          <!-- take a look at the javaflow docs for more info on what this verifier does -->
           <verifyGetters>true</verifyGetters>
         </verifications>
       </api>

--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,9 @@ Add the following to the plugins section of your `pom.xml` file.
           <java.math.BigDecimal>number</java.math.BigDecimal>
         </types>
         <verifications>
+          <!-- optional flag specifying if the engine should verify that -->
+          <!-- the number of getters is the same as the number of fields and -->
+          <!-- the types of the fields are the same as the types returned from the getters -->
           <verifyGetters>true</verifyGetters>
         </verifications>
       </api>


### PR DESCRIPTION
Hi @havardh,

I struggled for quite a few hours to have `lombok` and `javaflow` work together, only to discover that the `verifyGetters` flag was the one causing my troubles (no getters in the classes since lombok adds them at compile time), so I updated the readme to have more info on this flag.

In case someone else has this issue, disabling the flag with `false` or omitting it completely worked fine.

Regards,
Goce